### PR TITLE
README copyedit and testing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#mapshaper
+# mapshaper
 
-###Introduction
+### Introduction
 
 Mapshaper is a program for simplifying cartographic lines while preserving the topological relationships between adjacent polygons and intersecting polyline paths. It can read and write Shapefile and GeoJSON files and can also export [TopoJSON](https://github.com/mbostock/topojson/wiki) files. The current version can be found at [mapshaper.org](http://www.mapshaper.org).
 
 This software is loosely based on the original MapShaper program that I wrote at the University of Wisconsin, Madison in 2006-2007. That version is still available [here](http://mapshaper.com/test/OldMapShaper.swf).
 
-The new mapshaper was rewritten from scratch in JavaScript and improves on the original in a few ways. The earlier program sent data to a server to be processed; the new version does all its processing locally, so the program can be used offline and user data stays private. The new version has a better algorithm for topology processing. There is also a commandline script that runs in [Node.js](http://nodejs.org).
+The new mapshaper was rewritten from scratch in JavaScript and improves on the original in a few ways. The earlier program sent data to a server to be processed; the new version does all its processing locally, so the program can be used offline and user data stays private. The new version has a better algorithm for topology processing. There is also a command line script that runs in [Node.js](http://nodejs.org).
 
-###Interactive tool
+### Interactive tool
 
 To set up mapshaper's web interface for online use, copy the files in www/ to a web server. All processing is done in the browser; there is no backend service to run.
 
@@ -16,9 +16,9 @@ Browser compatibility: The web interface works well in recent versions of Chrome
 
 To run the mapshaper gui directly from the filesystem, open www/index.html in a web browser. Firefox works well in this mode; offline exporting is not fully supported in Chrome.
 
-###Commandline tool
+### Command line tool
 
-bin/mapshaper is a [Node.js](http://nodejs.org) script. It was developed on OS X and is untested on other platforms.
+bin/mapshaper is a [Node.js](http://nodejs.org) script. It was developed on OS X and has also been used successfully on Ubuntu 13.04 and Windows 8.
  
 `$ mapshaper -p 0.1 counties.shp`  Retain 10% of removable vertices using default simplification.
 
@@ -26,22 +26,22 @@ bin/mapshaper is a [Node.js](http://nodejs.org) script. It was developed on OS X
 
 `$ mapshaper -h` Read a help message.
 
-###Building and testing
+### Building and testing
 
-You will need to regenerate mapshaper.js if you edit any of the files in the src/ or lib/ directories. Run `$ build` to update mapshaper.js (used by the commandline tool); run `$ build gui` to update www/mapshaper.js (used by the web interface). The build script requires [Node.js](http://nodejs.org).
+You will need to regenerate mapshaper.js if you edit any of the files in the src/ or lib/ directories. Run `$ build` to update mapshaper.js (used by the command line tool); run `$ build gui` to update www/mapshaper.js (used by the web interface). The build script requires [Node.js](http://nodejs.org).
 
 `$ build [gui] -f` continuously monitors source files and regenerates  mapshaper.js whenever a source file is modified.
 
 Run `$ mocha` in the project directory to run mapshaper's unit tests.
 
 
-###License
+### License
 
 This software is licensed under the [MPL](http://www.mozilla.org/MPL/2.0/) 2.0
 
 According to Mozilla's [FAQ](http://www.mozilla.org/MPL/2.0/FAQ.html), "The MPL's "file-level" copyleft is designed to encourage contributors to share modifications they make to your code, while still allowing them to combine your code with code under other licenses (open or proprietary) with minimal restrictions."
 
-###Upcoming features + wish list
+### Upcoming features + wish list
 
 To suggest additions to this list, add an [issue](https://github.com/mbloch/mapshaper/issues).
 


### PR DESCRIPTION
1. Runs fine on Windows 8 and Ubuntu 13.04!
2. "Command line" is two words. :-)
3. Use # heading instead of #heading
   (compatible with more Markdown processors)
