### PR TITLE
Pass files to the mapshaper-gui command line

### DIFF
--- a/bin/mapshaper-gui
+++ b/bin/mapshaper-gui
@@ -8,7 +8,7 @@ var http = require("http"),
     optimist = require("optimist");
 
 var defaultPort = 5555,
-    usage = "Usage: $ mapshaper-gui [options]",
+    usage = "Usage: $ mapshaper-gui [options] [path/to/file.geojson]",
     opts = optimist.usage(usage)
 
   .options("h", {
@@ -28,12 +28,23 @@ var defaultPort = 5555,
       optimist.showHelp();
       process.exit(0);
     }
+    if (argv._.length) {
+      if (argv._.length != 1) {
+        optimist.showHelp();
+        process.exit(0);
+      }
+      if (!fs.existsSync(argv._[0])) {
+        console.error('File ', argv._[0], ' does not exist.');
+        process.exit(1);
+      }
+    }
   })
   .argv;
 
 var webRoot = path.join(__dirname, "../www"),
     port = opts.port || defaultPort,
-    indexUrl = "http://localhost:" + port + "/index.html";
+    indexUrl = "http://localhost:" + port + "/index.html",
+    dataFilename = opts._[0];
 
 process.on('uncaughtException', function(err) {
   if (err.errno === 'EADDRINUSE')
@@ -43,34 +54,46 @@ process.on('uncaughtException', function(err) {
 
 serveOnPort(webRoot, port);
 
+function serveFile(filename, response) {
+  fs.exists(filename, function(exists) {
+    if(!exists) {
+      response.writeHead(404, {"Content-Type": "text/plain"});
+      response.write("404 Not Found\n");
+      response.end();
+      return;
+    }
+
+    if (fs.statSync(filename).isDirectory()) filename += '/index.html';
+
+    fs.readFile(filename, "binary", function(err, file) {
+      if(err) {
+        response.writeHead(500, {"Content-Type": "text/plain"});
+        response.write(err + "\n");
+        response.end();
+        return;
+      }
+
+      response.writeHead(200);
+      response.write(file, "binary");
+      response.end();
+    });
+  });
+}
+
 function serveOnPort(www, port) {
   http.createServer(function(request, response) {
     var uri = url.parse(request.url).pathname
       , filename = path.join(www, uri);
 
-    fs.exists(filename, function(exists) {
-      if(!exists) {
-        response.writeHead(404, {"Content-Type": "text/plain"});
-        response.write("404 Not Found\n");
-        response.end();
-        return;
-      }
-
-      if (fs.statSync(filename).isDirectory()) filename += '/index.html';
-
-      fs.readFile(filename, "binary", function(err, file) {
-        if(err) {
-          response.writeHead(500, {"Content-Type": "text/plain"});
-          response.write(err + "\n");
-          response.end();
-          return;
-        }
-
-        response.writeHead(200);
-        response.write(file, "binary");
-        response.end();
-      });
-    });
+    if (request.url === '/cli/data') {
+      serveFile(dataFilename, response);
+    } else if (request.url === '/cli/filename') {
+      response.writeHead(200);
+      response.write(JSON.stringify(dataFilename || null));
+      response.end();
+    } else {
+      serveFile(filename, response);
+    }
   }).listen(parseInt(port, 10), onListening);
 }
 

--- a/src/gui/mapshaper-import-control.js
+++ b/src/gui/mapshaper-import-control.js
@@ -282,4 +282,22 @@ function ImportControl(model) {
       });
     }, 35);
   }
+
+  // Check whether a file was requested from the command line.
+  if (window.fetch) {
+    fetch('/cli/filename')
+      .then(function(response) {
+        return response.text();
+      }).then(function(filename) {
+        if (!filename) return;
+
+        fetch('/cli/data')
+          .then(function(response) {
+            return response.text();
+          }).then(function(text) {
+            console.log('Loading ', text.length, ' bytes from ', filename);
+            readFileContent(filename, text);
+          });
+      })
+  }
 }


### PR DESCRIPTION
Fixes #32 

This:

- Serves the file name via `/cli/filename`
- Serves the file content via `/cli/data`
- Hits the first on page load, then the second if it returns non-`null`.

I verified that you can quickly open GeoJSON and TopoJSON files via the CLI this way. It doesn't seem to work with Shapefiles yet (I tried `test_data/six_counties.shp` without success). I'd prefer to punt on that for the time being.

Let me know if this seems like a reasonable approach. There may be a smarter place to call `readFileContent` than in `ImportControl`. I chose to do it there because all the methods I needed were in scope.