### PR TITLE
in SVG export, give top layer g element id="<filename>-<layername>"

### DIFF
--- a/src/io/mapshaper-export.js
+++ b/src/io/mapshaper-export.js
@@ -78,9 +78,13 @@ internal.exportFileContent = function(dataset, opts) {
   }, dataset);
 
   // Adjust layer names, so they can be used as output file names
-  if (opts.file && outFmt != 'topojson') {
+  if (opts.file && ['topojson','svg'].indexOf(outFmt) == -1) {
     dataset.layers.forEach(function(lyr) {
       lyr.name = utils.getFileBase(opts.file);
+    });
+  } else if (opts.file && outFmt == 'svg' && dataset.layers.length > 1) {
+    dataset.layers.forEach(function(lyr) {
+      lyr.name = utils.getFileBase(opts.file) + '-' + lyr.name;
     });
   }
   internal.assignUniqueLayerNames(dataset.layers);


### PR DESCRIPTION
* To facilitate CSS/JS-targeting using ID when layers order and complement change frequently
* Also easier to keep track of layers in Illustrator