### PR TITLE
Changed `open` package to `opn`, fixes #282

### DIFF
--- a/bin/mapshaper-gui
+++ b/bin/mapshaper-gui
@@ -5,7 +5,7 @@ var http = require("http"),
     url = require("url"),
     fs = require("fs"),
     Cookies = require("cookies"),
-    open = require("open"),
+    opn = require("opn"),
     optimist = require("optimist"),
     defaultPort = 5555,
     webRoot = path.join(__dirname, "../www"),
@@ -101,7 +101,7 @@ function startServer(port) {
       serveFile(path.join(webRoot, uri), response);
     }
   }).listen(port, function() {
-    open("http://localhost:" + port);
+    opn("http://localhost:" + port);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"d3-dsv": "~1.0.8",
 		"iconv-lite": "0.4.19",
 		"mproj": "0.0.16",
-		"open": "~0.0.5",
+		"opn": "^5.3.0",
 		"optimist": "~0.6.0",
 		"rbush": "~2.0.1",
 		"rw": "~1.3.3"
@@ -44,7 +44,7 @@
 		"deep-eql": ">=0.1.3",
 		"catty": "0.0.6",
 		"browserify": "~14.4.0",
-    "underscore": "^1.9.0"
+		"underscore": "^1.9.0"
 	},
 	"bin": {
 		"mapshaper": "./bin/mapshaper",


### PR DESCRIPTION
* Changed `open` package dependency to `opn` because of a critical vulnerability: https://nodesecurity.io/advisories/663
* Fixes #282 