### PR TITLE
svg output point-symbol=line and -style rotate=

### DIFF
--- a/src/cli/mapshaper-options.js
+++ b/src/cli/mapshaper-options.js
@@ -903,6 +903,9 @@ internal.getOptionParser = function() {
      .option("line-height", {
       describe: 'line spacing of multi-line labels (default is 1.1em)'
     })
+    .option("rotate", {
+      describe: "(SVG) rotation in degrees applied on symbol (default is 0, clockwise)"
+    })
    .option("target", targetOpt);
 
   parser.command("target")

--- a/src/svg/geojson-to-svg.js
+++ b/src/svg/geojson-to-svg.js
@@ -163,19 +163,40 @@ SVG.importStandardPoint = function(coords, rec, layerOpts) {
   var symbolType = layerOpts.point_symbol || '';
   var children = [];
   var halfSize = rec.r || 0; // radius or half of symbol size
+  var deg2rad = Math.PI / 180;
+  var symbolRotate = (+rec.rotate || 0) * deg2rad; // rotation applied on symbol around point's center
   var p;
   // if not a label, create a symbol even without a size
   // (circle radius can be set via CSS)
   if (halfSize > 0 || !isLabel) {
     if (symbolType == 'square') {
+      var squareRotate = symbolRotate + Math.PI * .25 // Rotate by 45 degrees to make the square sit straight
+      var squareLength = halfSize * Math.sqrt(2) // From the half-diagonal, get square's length
       p = {
-        tag: 'rect',
+        tag: 'polygon',
         properties: {
-          x: coords[0] - halfSize,
-          y: coords[1] - halfSize,
-          width: halfSize * 2,
-          height: halfSize * 2
-        }};
+          points: [
+            [coords[0] + squareLength * Math.cos(squareRotate), coords[1] + squareLength * Math.sin(squareRotate)],
+            [coords[0] + squareLength * Math.cos(squareRotate + Math.PI * .5), coords[1] + squareLength * Math.sin(squareRotate + Math.PI * .5)],
+            [coords[0] + squareLength * Math.cos(squareRotate + Math.PI), coords[1] + squareLength * Math.sin(squareRotate + Math.PI)],
+            [coords[0] + squareLength * Math.cos(squareRotate + Math.PI * -.5), coords[1] + squareLength * Math.sin(squareRotate + Math.PI * -.5)]
+          ]
+          .map(function(pt) {
+            return pt.join(',') // joining two dimensions of point
+          })
+          .join(',') // join each point string coordinates
+        }
+      };
+    } else if (symbolType == 'line') {
+      var lineLength = halfSize ** 2 //
+      p = {
+        tag: 'line',
+        properties: {
+          x1: coords[0],
+          y1: coords[1],
+          x2: coords[0] + lineLength * Math.cos(symbolRotate),
+          y2: coords[1] + lineLength * Math.sin(symbolRotate)
+      }};
     } else { // default is circle
       p = {
         tag: 'circle',

--- a/src/svg/geojson-to-svg.js
+++ b/src/svg/geojson-to-svg.js
@@ -188,7 +188,7 @@ SVG.importStandardPoint = function(coords, rec, layerOpts) {
         }
       };
     } else if (symbolType == 'line') {
-      var lineLength = halfSize ** 2 //
+      var lineLength = Math.pow(halfSize, 2) //
       p = {
         tag: 'line',
         properties: {

--- a/src/svg/svg-common.js
+++ b/src/svg/svg-common.js
@@ -12,19 +12,20 @@ SVG.propertyTypes = {
   'line-height': 'measure',
   'letter-spacing': 'measure',
   'stroke-width': 'number',
-  'stroke-dasharray': 'dasharray'
+  'stroke-dasharray': 'dasharray',
+  rotate: 'number'
 };
 
 SVG.symbolRenderers = {};
 SVG.furnitureRenderers = {};
 
-SVG.supportedProperties = 'class,opacity,stroke,stroke-width,stroke-dasharray,fill,r,dx,dy,font-family,font-size,text-anchor,font-weight,font-style,line-height,letter-spacing'.split(',');
+SVG.supportedProperties = 'class,opacity,stroke,stroke-width,stroke-dasharray,fill,r,dx,dy,font-family,font-size,text-anchor,font-weight,font-style,line-height,letter-spacing,rotate'.split(',');
 SVG.commonProperties = 'class,opacity,stroke,stroke-width,stroke-dasharray'.split(',');
 
 SVG.propertiesBySymbolType = {
   polygon: utils.arrayToIndex(SVG.commonProperties.concat('fill')),
   polyline: utils.arrayToIndex(SVG.commonProperties),
-  point: utils.arrayToIndex(SVG.commonProperties.concat('fill', 'r')),
+  point: utils.arrayToIndex(SVG.commonProperties.concat('fill', 'r', 'rotate')),
   label: utils.arrayToIndex(SVG.commonProperties.concat(
     'fill,r,font-family,font-size,text-anchor,font-weight,font-style,letter-spacing,dominant-baseline'.split(',')))
 };

--- a/test/geojson-to-svg-test.js
+++ b/test/geojson-to-svg-test.js
@@ -78,8 +78,8 @@ describe('geojson-to-svg.js', function () {
         geometry: {type: 'Point', coordinates: [5, 5]}
       };
       var expected = [{
-        tag: 'rect',
-        properties: {x: 3, y: 3, width: 4, height: 4}
+        tag: 'polygon',
+        properties: {points: "7,7,3,7,2.9999999999999996,3,7,3"}
       }];
       assert.deepEqual(SVG.importGeoJSONFeatures([geo], {point_symbol: 'square'}), expected)
 
@@ -94,8 +94,8 @@ describe('geojson-to-svg.js', function () {
       var expected = [{
         tag: 'g',
         children: [{
-          tag: 'rect',
-          properties: {x: 3, y: 3, width: 4, height: 4}
+          tag: 'polygon',
+          properties: {points: "7,7,3,7,2.9999999999999996,3,7,3"}
         }, {
           tag: 'text',
           value: 'foo',


### PR DESCRIPTION
* added support for drawing a line as a `point-symbol=` on svg output
* added support to rotate a point symbol using data
  * could clash with desired software design, by adding an attribute on the point feature called `rotate=`... I did it that way, because I wanted to be able to use expressions and layer data to provide an arbitrary rotation based on data. The immediate desire was to let people use an `r=` that remains a radius, which has to be positive and generally the `Math.sqrt()` of a numeric value we want to represent.
* the line starts at the feature's specified point, and goes in the direction of the rotation
* refactored the square `point-symbol`
  * now a polygon instead of a rect, so that it can be rotated without having to use `transform()` and much weirdness in the maths (since the origin isn't the point itself, but the whole svg).
  * instead, we use `Math.cos()` and `Math.sin()` to translate the coordinates of the four vertices
  * the square is actually ["standing up"](https://en.wikipedia.org/wiki/Square#/media/File:Regular_polygon_4_annotated.svg) and we apply a 45-degree rotation by default to make the square with its side perpendicular and parallel with the canvas'.
* tried outputting a test SVG using U.S. counties and some data in the `MY_DATA_FIELD` column:
  * test `-style` command is: `-style r='Math.sqrt(Math.abs(MY_DATA_FIELD))' rotate='MY_DATA_FIELD >= 0 ? -90 : 90' stroke='COLOR' opacity='.5' fill='none' target=POINTS_LAYER`
  * try with `point-symbol=line` in the `-output` command
  * in Illustrator, I was able to select lines and apply an a arrow style (the right side arrow in the Illustrator stroke dialog was applied on the side of the `x2, y2` point, so pointing away from the point's center)
* there was a previous iteration of this that worked where I had `point-symbol-rotate=` (and a numeric degree value as argument) in `-output`, but I couldn't find how to evaluate expressions...