### PR TITLE
point-text option in -style to provide text tag symbol as point

### DIFF
--- a/src/cli/mapshaper-options.js
+++ b/src/cli/mapshaper-options.js
@@ -876,6 +876,9 @@ internal.getOptionParser = function() {
     .option("label-text", {
       describe: 'label text (set this to export points as labels)'
     })
+    .option("point-text", {
+      describe: 'point symbol text (a text symbol replaces path or circle)'
+    })
     .option("text-anchor", {
       describe: 'label alignment; one of: start, end, middle (default)'
     })

--- a/src/commands/mapshaper-svg-style.js
+++ b/src/commands/mapshaper-svg-style.js
@@ -30,7 +30,7 @@ api.svgStyle = function(lyr, dataset, opts) {
 };
 
 internal.isSupportedSvgProperty = function(name) {
-  return SVG.supportedProperties.indexOf(name) > -1 || name == 'label-text';
+  return SVG.supportedProperties.indexOf(name) > -1 || name == 'label-text' || name == 'point-text';
 };
 
 // returns parsed value or null if @strVal is not recognized as a valid literal value

--- a/src/svg/geojson-to-svg.js
+++ b/src/svg/geojson-to-svg.js
@@ -167,7 +167,20 @@ SVG.importStandardPoint = function(coords, rec, layerOpts) {
   // if not a label, create a symbol even without a size
   // (circle radius can be set via CSS)
   if (halfSize > 0 || !isLabel) {
-    if (symbolType == 'square') {
+    if (symbolType == 'text') {
+      p = {
+        tag: 'text',
+        properties: {
+          x: coords[0],
+          y: coords[1],
+          dx: 0,
+          dy: rec['font-size'] ? rec['font-size'] / 4 : 7,
+          'font-size': rec['font-size'] ? rec['font-size'] - 2 : 10,
+          'text-anchor': 'middle'
+        },
+        value: rec['point-text'] ? rec['point-text'] : '●'
+      }
+    } else if (symbolType == 'square') {
       p = {
         tag: 'rect',
         properties: {


### PR DESCRIPTION
This is old code from January. I'm not sure if I should just start over with the latest commits, or we can just attempt to merge. At least, we can discuss that.

The goal is to provide a way in SVG output to specify a `<text>` tag to output in place of a circle or rect, as the point's element on the map. That's for use cases where we have glyphs in a custom font, say airport or seaport symbols, that we want to render as text. Not sure if there are other ways to render on the map...