### PR TITLE
fix GeoJSONReader: reset buffer size

### DIFF
--- a/src/geojson/geojson-reader.js
+++ b/src/geojson/geojson-reader.js
@@ -24,6 +24,7 @@ export function GeoJSONReader(reader) {
     var obj = readObject(offset);
     var json;
     while (obj) {
+      reader.resetBuffer();
       try {
         json = JSON.parse(obj.text);
       } catch(e) {

--- a/src/io/mapshaper-file-reader.js
+++ b/src/io/mapshaper-file-reader.js
@@ -81,6 +81,11 @@ export function FileReader(path, opts) {
     return this;
   };
 
+  this.resetBuffer = function() {
+    DEFAULT_BUFFER_LEN = opts && opts.bufferSize || 0x40000;
+    return this;
+  };
+
   // Read to BinArray (for compatibility with ShpReader)
   this.readToBinArray = function(start, length) {
     if (updateCache(start, length)) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -43,6 +43,11 @@ function Reader(str, chunkLen) {
     chunkLen *= 2;
     return this;
   };
+
+  this.resetBuffer = function() {
+    chunkLen = 256;
+    return this;
+  };
 }
 
 Reader.prototype.findString = api.internal.FileReader.prototype.findString;


### PR DESCRIPTION
I am working with really big geojson files (around 2GB and more).

I noticed that the mapshaper cli takes forever reading such a file.

I dove deep into the mapshaper code and I noticed that the GeoJSONReader only increases the buffer size from the FileReader but never resets it. This is a huge performance loss and it becomes even more noticeable with very large GeoJSON files.

I am using this command to simplify such big geojson files:
```bash
mapshaper-xl -i results_sentinel_snow_vectorized_minified.geojson encoding=us-ascii no-topology -simplify 10% -filter remove-empty -o format=geojson output.json -verbose
```

With my code adjustments, the runtime for my example reduces from **3h+** to **1m23s**.

<br/>
If you want to try it yourself, I uploaded the file from my example here:

https://mega.nz/file/WhhXlSjT#ORLKtnxPUXwI3NoXeMAge80Ey8JA1PgZaDocyaYJTPE

_(the data in the geojson shows snow-coverage measured from a satellite)_

