### PR TITLE
fix invalid point grid params check

### DIFF
--- a/src/commands/mapshaper-point-grid.js
+++ b/src/commands/mapshaper-point-grid.js
@@ -70,7 +70,7 @@ function createPointGrid(opts) {
     y0 = bbox[1] + dy / 2;
   }
 
-  if (dx > 0 === false || dy > 0 === false) {
+  if (dx <= 0 || dy <= 0) {
     stop('Invalid grid parameters');
   }
 


### PR DESCRIPTION
Hi Matt, this PR update fixes the condition that triggers the 'Invalid grid parameters' error on `-point-grid`.

The current condition is `if (dx > 0 === false || dy > 0 === false)`. But since `===` takes precedence over  `>`, and `0 === false` is false, the condition was actually checking whether `dx > false || dy > false`.