### PR TITLE
Add alternative featurecollection reader

### DIFF
--- a/src/cli/mapshaper-options.js
+++ b/src/cli/mapshaper-options.js
@@ -181,6 +181,10 @@ export function getOptionParser() {
     .option('json-path', {
       old_alias: 'json-subtree',
       describe: '[JSON] path to JSON input data; separator is /'
+    })
+    .option('big-geojson', {
+      describe: 'Use alternative reader, to read a FeatureCollection from a big (2GB+) GeoJSON file.',
+      type: 'flag'
     });
 
   parser.command('o')

--- a/src/geojson/big-geojson-reader.js
+++ b/src/geojson/big-geojson-reader.js
@@ -1,0 +1,456 @@
+const fs = require('fs')
+import { verbose } from '../utils/mapshaper-logging'
+import { T } from '../utils/mapshaper-timing'
+
+const SQUARE_BRACKET_OPEN = new Uint8Array(Buffer.from('[', 'utf-8'))[0]
+const SQUARE_BRACKET_CLOSE = new Uint8Array(Buffer.from(']', 'utf-8'))[0]
+const SPACE = new Uint8Array(Buffer.from(' ', 'utf-8'))[0]
+const COMMA = new Uint8Array(Buffer.from(',', 'utf-8'))[0]
+const NEW_LINE = 10
+const NUMBER = new Uint8Array(Buffer.from('0123456789.', 'utf-8'))
+
+/**
+ * Wrapper class over a two dimensional array, which mimics to be a one dimensional array.
+ * (So we can have arrays longer than max array length.)
+ */
+class MyBigArray {
+  constructor (options = { chunkSize: 10000000 }) {
+    this.chunkSize = options.chunkSize
+    this.mainArr = [[]]
+    this.length = 0
+  }
+
+  push (e) {
+    if (this.mainArr[this.mainArr.length - 1].length < this.chunkSize) {
+      this.mainArr[this.mainArr.length - 1].push(e)
+    } else {
+      this.mainArr.push([e])
+    }
+    this.length++
+  }
+
+  get (i = 0) {
+    const chunkNo = Math.floor(i / this.chunkSize)
+    const indexInChunk = i - (chunkNo * this.chunkSize)
+    return this.mainArr[chunkNo][indexInChunk]
+  }
+}
+
+/**
+ * Wrapper class over an array of buffers, which mimics to be one big buffer.
+ * (To tackle the problem of max buffer size = 2GB)
+ */
+class MyBigBuffer {
+  constructor (options = { chunkSize: 250000000 }) {
+    this.chunkSize = options.chunkSize
+    this.bufferArr = []
+    this.uint8Arr = []
+    this.length = 0
+  }
+
+  /**
+   * Reads provided file into an array of buffers.
+   * @param {String} geoJsonPath
+   */
+  load (geoJsonPath = '') {
+    const size = fs.statSync(geoJsonPath).size
+    const fd = fs.openSync(geoJsonPath, 'r')
+
+    for (let i = 0; i < size; i += this.chunkSize) {
+      const bufferSize = size - i < this.chunkSize ? size - i : this.chunkSize
+      const chunk = Buffer.alloc(bufferSize)
+
+      fs.readSync(fd, chunk, 0, bufferSize, i)
+
+      this.bufferArr.push(chunk)
+      this.uint8Arr.push(new Uint8Array(chunk))
+      this.length += chunk.length
+    }
+  }
+
+  /**
+   * Returns byte (Uint8) at position i
+   * @param {Number} i 
+   */
+  get (i = 0) {
+    const chunkNo = Math.floor(i / this.chunkSize)
+    const indexInChunk = i - (chunkNo * this.chunkSize)
+
+    return this.uint8Arr[chunkNo][indexInChunk]
+  }
+
+  /**
+   * Checks if this big buffer contains the provided string,
+   * at the provided position start.
+   * @param {Uint8Array} stringUint8Array string in uint8 array
+   * @param {Number} start start index in this big buffer
+   */
+  checkStringMatch (stringUint8Array, start) {
+    if (stringUint8Array.length + start > this.length - 1) return false
+    for (let i = start; i < start + stringUint8Array.length; i++) {
+      if (this.get(i) !== stringUint8Array[i - start]) return false
+    }
+    return true
+  }
+
+  /**
+   * finds occurrences of the provided chars/strings in byte format
+   * @param {Array.Uint8Array} arr array of Uint8Array
+   */
+  findOccurrences (arr = [new Uint8Array(Buffer.from('{'))]) {
+    const singleByteElements = arr.filter(e => e.length > 0 && e.length < 2).map(e => e[0])
+    const multiByteElements = arr.filter(e => e.length > 1)
+
+    const occurrences = []
+    arr.forEach(() => { occurrences.push(new MyBigArray()) })
+
+    /* eslint no-labels: ["error", { "allowLoop": true }] */
+    bufferIteration:
+    for (let i = 0; i < this.length; i++) {
+      const chunkNo = Math.floor(i / this.chunkSize)
+      const indexInChunk = i - (chunkNo * this.chunkSize)
+
+      for (let j = 0; j < singleByteElements.length; j++) {
+        if (singleByteElements[j] === this.uint8Arr[chunkNo][indexInChunk]) {
+          occurrences[j].push(i)
+          continue bufferIteration
+        }
+      }
+
+      for (let j = 0; j < multiByteElements.length; j++) {
+        if (multiByteElements[j][0] === this.uint8Arr[chunkNo][indexInChunk]) {
+          if (this.checkStringMatch(multiByteElements[j], i)) {
+            occurrences[j + singleByteElements.length].push(i)
+            i += multiByteElements[j].length - 1
+            continue bufferIteration
+          }
+        }
+      }
+    }
+
+    return occurrences
+  }
+
+  /**
+   * Returns the slice of the range defined by the provided indices in string format
+   * @param {Number} start inclusive index
+   * @param {Number} end inclusive index
+   */
+  sliceToString (start, end) {
+    end += 1
+    const startChunkNo = Math.floor(start / this.chunkSize)
+    const startIndexInChunk = start - (startChunkNo * this.chunkSize)
+    const endChunkNo = Math.floor(end / this.chunkSize)
+    const endIndexInChunk = end - (endChunkNo * this.chunkSize)
+
+    let string
+
+    if (startChunkNo === endChunkNo) {
+      // if start and end are in one an the same chunk
+
+      string = this.bufferArr[startChunkNo].slice(startIndexInChunk, endIndexInChunk).toString()
+    } else if (endChunkNo - startChunkNo === 1) {
+      // if start and end are in two consecutively chunks
+
+      const firstPart = this.bufferArr[startChunkNo].slice(startIndexInChunk)
+      const lastPart = this.bufferArr[endChunkNo].slice(0, endIndexInChunk)
+      string = Buffer.concat([firstPart, lastPart]).toString()
+    } else {
+      // if start and end span over more than two chunks
+
+      const firstPart = this.bufferArr[startChunkNo].slice(startIndexInChunk)
+      const lastPart = this.bufferArr[endChunkNo].slice(0, endIndexInChunk)
+
+      const parts = [firstPart]
+      for (let i = startChunkNo + 1; i < endChunkNo - 1; i++) {
+        parts.push(this.bufferArr[i].slice(0, this.chunkSize))
+      }
+      parts.push(lastPart)
+
+      string = Buffer.concat(parts).toString()
+    }
+
+    return string
+  }
+
+  /**
+   * Parses multiple slices of this buffer to one JSON.
+   * @param {Array} arr [{ start: 0, end: 10}, { start: 15, end: 20}]
+   */
+  multiSlicesToJSON (arr) {
+    let string = ''
+    let json
+
+    for (const elem of arr) {
+      string += this.sliceToString(elem.start, elem.end)
+    }
+
+    try {
+      json = JSON.parse(string)
+    } catch (error) {
+      console.error(`Failed to parse string to json: ${string}`)
+      throw error
+    }
+
+    return json
+  }
+
+  /**
+   * Returns the slice of the range defined by the provided indices in JSON format
+   * @param {Number} start index inclusive
+   * @param {Number} end index inclusive
+   */
+  sliceToJSON (start, end) {
+    const string = this.sliceToString(start, end)
+    let json
+
+    try {
+      json = JSON.parse(string)
+    } catch (error) {
+      console.error(`Failed to parse string to json: ${string}`)
+      throw error
+    }
+
+    return json
+  }
+
+  /**
+   * Parses an arbitrarily nested array of numbers iteratively from this buffer.
+   * @param {Number} start index inclusive
+   * @param {Number} end index inclusive
+   */
+  parseNumberArray (start, end) {
+    let result
+    const stack = []
+
+    // iterate over all bytes of provided buffer range
+    for (let i = start; i <= end; i++) {
+      // get byte at position i
+      const n = this.get(i)
+      if (n === SPACE || n === NEW_LINE || n === COMMA) continue
+      else if (n === SQUARE_BRACKET_OPEN) {
+        // if byte is square bracket open: add new array to stack
+        stack.push([])
+      } else if (n === SQUARE_BRACKET_CLOSE) {
+        /*
+        if byte is close square bracket: pop last array from stack:
+          if there are still elements in the stack: add the popped array into the last array on the stack
+          if the stack is empty: it has to be the end of the most outer array: set result variable
+        */
+        const lastElem = stack.pop()
+        if (stack.length > 0) {
+          stack[stack.length - 1].push(lastElem)
+        } else if (stack.length === 0 && i === end) {
+          result = lastElem
+        } else {
+          throw new Error('Unexpected array closing.')
+        }
+      } else if (NUMBER.includes(n)) {
+        // find start and end index of number in buffer
+        let endIndex = i
+        while (endIndex <= end && NUMBER.includes(this.get(endIndex))) endIndex++
+        // revert last iteration of while
+        endIndex--
+        // parse number from string from buffer slice
+        const num = Number(this.sliceToString(i, endIndex))
+
+        // there has to be an array on the stack, which contains the just parsed number
+        if (stack.length > 0) {
+          stack[stack.length - 1].push(num)
+        } else {
+          throw new Error('Found number at unexpected position in array.')
+        }
+
+        // move i to end of number
+        i = endIndex
+      } else {
+        throw new Error(`Found unexpected byte in number array: ${n}`)
+      }
+    }
+
+    return result
+  }
+}
+
+export class BigGeoJSONReader {
+  /**
+   * @param {Number} options.maxDirectJsonParseByteCount How long a feature can be in bytes so that it is parsed directly to json.
+   * @param {Number} options.bufferChunkSize In how big chunks the geojson file should be read.
+   */
+  constructor (options = { maxDirectJsonParseByteCount: 250000000, bufferChunkSize: 250000000 }) {
+    this.bigBuffer = new MyBigBuffer({ chunkSize: options.bufferChunkSize })
+    this.features = []
+    this.maxDirectJsonParseByteCount = options.maxDirectJsonParseByteCount
+  }
+
+  loadGeoJSONFile (file) {
+    const toFind = [
+      new Uint8Array(Buffer.from('{', 'utf-8')),
+      new Uint8Array(Buffer.from('}', 'utf-8')),
+      new Uint8Array(Buffer.from('[', 'utf-8')),
+      new Uint8Array(Buffer.from(']', 'utf-8')),
+      new Uint8Array(Buffer.from('Feature"', 'utf-8'))
+    ]
+
+    // load file into chunks of Buffer objects
+    this.bigBuffer.load(file)
+
+    T.start()
+    // find occurrences of specific chars / words
+    const occ = this.bigBuffer.findOccurrences(toFind)
+    T.stop('find occurrences')
+
+    T.start()
+    // array of indices of '{' char
+    const curvedBracketsOpen = occ[0]
+    // array of indices of '}' char
+    const curvedBracketsClose = occ[1]
+    // array of indices of '[' char
+    const squareBracketOpen = occ[2]
+    // array of indices of ']' char
+    const squareBracketClose = occ[3]
+    // array of starting indices of string: 'Feature"'
+    const feature = occ[4]
+
+    // simple stack to keep track of opened objects/arrays
+    const stack = []
+
+    // array to save starting and end indices of all features in the bigBuffer
+    this.features = []
+
+    // control variables to save current position of every index-array
+    let curvedBracketsOpenIndex = 0
+    let curvedBracketsCloseIndex = 0
+    let squareBracketOpenIndex = 0
+    let squareBracketCloseIndex = 0
+    let featureIndex = 0
+
+    /*
+    While there are still unviewd Objects/Arrays
+    */
+    while (curvedBracketsOpenIndex < curvedBracketsOpen.length ||
+          curvedBracketsCloseIndex < curvedBracketsClose.length ||
+          squareBracketOpenIndex < squareBracketOpen.length ||
+          squareBracketCloseIndex < squareBracketClose.length) {
+      /*
+      Find the next nearest index of char,
+      from our bucket of chars. ('{', '}', '[')
+      */
+      const min = Math.min(curvedBracketsOpen.get(curvedBracketsOpenIndex) ?? Infinity,
+        curvedBracketsClose.get(curvedBracketsCloseIndex) ?? Infinity,
+        squareBracketOpen.get(squareBracketOpenIndex) ?? Infinity,
+        squareBracketClose.get(squareBracketCloseIndex) ?? Infinity,
+        feature.get(featureIndex) ?? Infinity)
+
+      if (curvedBracketsOpen.get(curvedBracketsOpenIndex) === min) {
+        // if the next char is a open curved bracket
+
+        curvedBracketsOpenIndex++
+        stack.push({ char: '{', index: min })
+      } else if (curvedBracketsClose.get(curvedBracketsCloseIndex) === min) {
+        // if the next char is a close curved bracket
+
+        if (stack.length > 0 && stack[stack.length - 1].char === '{') {
+          curvedBracketsCloseIndex++
+
+          const isFeature = !!stack[stack.length - 1].isFeature
+          const coordinates = stack[stack.length - 1].coordinates
+
+          const start = stack.pop().index
+
+          if (isFeature) {
+            this.features.push({ start: start, end: min, coordinates: { start: coordinates[0], end: coordinates[1] } })
+          }
+        } else {
+          throw new Error('Unexpectd "}" character')
+        }
+      } else if (squareBracketOpen.get(squareBracketOpenIndex) === min) {
+        // if the next char is a open square bracket
+
+        if (stack.length > 0 && stack[stack.length - 1].char === '[') {
+          squareBracketOpenIndex++
+          squareBracketCloseIndex++
+        } else {
+          stack.push({ char: '[', index: min })
+          squareBracketOpenIndex++
+        }
+      } else if (squareBracketClose.get(squareBracketCloseIndex) === min) {
+        // if the next char is a close square bracket
+
+        if (stack.length > 0 && stack[stack.length - 1].char === '[') {
+          squareBracketCloseIndex++
+          const start = stack.pop().index
+          for (let i = stack.length - 1; i > -1; i--) {
+            if (stack[i].isFeature) {
+              stack[i].coordinates = [start, min]
+              break
+            }
+          }
+        } else {
+          console.log(stack)
+          throw new Error('Unexpectd "]" character')
+        }
+      } else if (feature.get(featureIndex) === min) {
+        // if the next char sequence is 'Feature"'
+
+        if (stack.length > 0 && stack[stack.length - 1].char === '{') {
+          featureIndex++
+          stack[stack.length - 1].isFeature = true
+        } else {
+          throw new Error('Unexpected type: Feature property')
+        }
+      } else {
+        throw new Error('Invalid Tree. Unexpected JSON control sequence.')
+      }
+    }
+    T.stop('interpret occurrences')
+
+    verbose(`Found ${this.features.length} features in ${file}.`)
+  }
+
+  /**
+   * Parses the individual features of the FeatureCollection and yields them one by one.
+   *
+   * If the byte count of one feature is less than "maxDirectJsonParseByteCount" it directly converts
+   * the byte range to a string and parses it to a json object.
+   * Otherwise it parses the feature without the coordinates array and parses the coordinates separately and iteratively.
+   * Then adds the seperately parsed coordinates array to the feature object.
+   */
+  * getFeatures () {
+    if (this.features.length < 1) throw new Error('No geojson file was loaded!')
+
+    // iterate over start/end indices of features
+    for (const featureIndices of this.features) {
+      const byteCount = featureIndices.end - featureIndices.start
+
+      if (byteCount < this.maxDirectJsonParseByteCount) {
+        const json = this.bigBuffer.sliceToJSON(featureIndices.start, featureIndices.end)
+        yield json
+      } else {
+        const arr = [
+          { start: featureIndices.start, end: featureIndices.coordinates.start },
+          { start: featureIndices.coordinates.end, end: featureIndices.end }
+        ]
+
+        // parse feature without coordinates array to json
+        const json = this.bigBuffer.multiSlicesToJSON(arr)
+
+        verbose('Found big feature. Parse coordinates array iteratively.')
+        T.start()
+        // parse coordinates array iteratively
+        const coordinates = this.bigBuffer.parseNumberArray(featureIndices.coordinates.start, featureIndices.coordinates.end)
+        T.stop('coordinates array parsed')
+
+        json.geometry.coordinates = coordinates
+
+        yield json
+      }
+    }
+  }
+
+  readObjects(cb) {
+    for (const feature of this.getFeatures()) {
+      cb(feature)
+    }
+  }
+}

--- a/src/geojson/big-geojson-reader.js
+++ b/src/geojson/big-geojson-reader.js
@@ -9,6 +9,10 @@ const COMMA = new Uint8Array(Buffer.from(',', 'utf-8'))[0]
 const NEW_LINE = 10
 const NUMBER = new Uint8Array(Buffer.from('0123456789.', 'utf-8'))
 
+// rewrite of: nullish coalescing operator '??'
+// because mocha test doesn't know it yet
+const nco = (a,b) => (a !== null && a !== undefined) ? a : b
+
 /**
  * Wrapper class over a two dimensional array, which mimics to be a one dimensional array.
  * (So we can have arrays longer than max array length.)
@@ -336,11 +340,11 @@ export class BigGeoJSONReader {
       Find the next nearest index of char,
       from our bucket of chars. ('{', '}', '[', ']', 'Feature"')
       */
-      const min = Math.min(curvedBracketsOpen.get(curvedBracketsOpenIndex) ?? Infinity,
-        curvedBracketsClose.get(curvedBracketsCloseIndex) ?? Infinity,
-        squareBracketOpen.get(squareBracketOpenIndex) ?? Infinity,
-        squareBracketClose.get(squareBracketCloseIndex) ?? Infinity,
-        feature.get(featureIndex) ?? Infinity)
+      const min = Math.min(nco(curvedBracketsOpen.get(curvedBracketsOpenIndex), Infinity),
+        nco(curvedBracketsClose.get(curvedBracketsCloseIndex), Infinity),
+        nco(squareBracketOpen.get(squareBracketOpenIndex), Infinity),
+        nco(squareBracketClose.get(squareBracketCloseIndex), Infinity),
+        nco(feature.get(featureIndex), Infinity))
 
       if (curvedBracketsOpen.get(curvedBracketsOpenIndex) === min) {
         // if the next char is a open curved bracket

--- a/src/geojson/big-geojson-reader.js
+++ b/src/geojson/big-geojson-reader.js
@@ -445,7 +445,9 @@ export class BigGeoJSONReader {
         // parse feature without coordinates array to json
         const json = this.bigBuffer.multiSlicesToJSON(arr)
 
-        verbose('Found big feature. Parse coordinates array iteratively.')
+        // Math.pow(2, 20) = 1048576 = 1MB
+        const coordinatesArrMB = Math.ceil((featureIndices.coordinates.end - featureIndices.coordinates.start) / Math.pow(2, 20))
+        verbose(`Found big feature (${coordinatesArrMB}MB). Parse coordinates array iteratively.`)
         T.start()
         // parse coordinates array iteratively
         const coordinates = this.bigBuffer.parseNumberArray(featureIndices.coordinates.start, featureIndices.coordinates.end)

--- a/src/io/mapshaper-json-import.js
+++ b/src/io/mapshaper-json-import.js
@@ -1,5 +1,6 @@
 
 import { GeoJSONParser, importGeoJSON } from '../geojson/geojson-import';
+import { BigGeoJSONReader } from '../geojson/big-geojson-reader'
 import { BufferReader, FileReader, readFirstChars } from '../io/mapshaper-file-reader';
 import utils from '../utils/mapshaper-utils';
 import { importTopoJSON } from '../topojson/topojson-import';
@@ -43,7 +44,17 @@ export function identifyJSONObject(o) {
 
 export function importGeoJSONFile(fileReader, opts) {
   var importer = new GeoJSONParser(opts);
-  new GeoJSONReader(fileReader).readObjects(importer.parseObject);
+
+  if (opts.big_geojson) {
+    for (const file of opts.files) {
+      const reader = new BigGeoJSONReader()
+      reader.loadGeoJSONFile(file)
+      reader.readObjects(importer.parseObject)
+    }
+  } else {
+    new GeoJSONReader(fileReader).readObjects(importer.parseObject);
+  }
+
   return importer.done();
 }
 


### PR DESCRIPTION
Adds an alternative FeatureCollection reader to tackle #461. 
So it is possible to read features from a FeatureCollection, which have a coordinates array, which exceeds node.js string/buffer limits.

Alternative reader is triggered with flag: `big-geojson`
For example:
```bash
mapshaper-xl 50g -i large_input.json big-geojson -simplify 10% -filter remove-empty -o format=geojson geojson-type=FeatureCollection simplified.json
```

-----------

After a specific file size and feature count (several million) this error can come up:
```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted (core dumped)
```
which can be solved by [increasing the mmap per process](https://stackoverflow.com/a/59923848/9135945): 
`sudo sysctl -w vm.max_map_count=655300` (this command just changes it until the next reboot)



