### PR TITLE
Add support to use manifest.js file in mapshaper-gui

### DIFF
--- a/bin/mapshaper-gui
+++ b/bin/mapshaper-gui
@@ -10,6 +10,7 @@ var defaultPort = 5555,
       .option('-f, --force-save', 'allow overwriting input files with output files')
       .option('-a, --display-all', 'turn on visibility of all layers')
       .option('-t, --target <name>', 'name of layer to select initially')
+      .option('-m, --manifest <pathmanifest>', 'name of layer to select initially')
       .helpOption('-h, --help', 'show this help message')
       .version(require('../package.json').version)
       .parse(),
@@ -69,7 +70,12 @@ function startServer(port) {
         new Cookies(request, response).set('session_id', sessionId);
       }
       // serve JS file containing manifest of files for mapshaper to load
-      serveContent(getManifestJS(dataFiles, opts), response, getMimeType(uri));
+      if (opts.manifest) {
+        var contentManifest = fs.readFileSync(opts.manifest, 'utf-8');
+      } else {      
+        var contentManifest = getManifestJS(dataFiles, opts);
+      }
+      serveContent(contentManifest, response, getMimeType(uri));
     } else if (uri.indexOf('/data/') === 0) {
       // serve a file from a path relative to this script
       // assumed to be a data file from the cmd line (!)


### PR DESCRIPTION
With this PR, do

`mapshaper-gui --manifest manifest.js` and get a custom GUI using the existing `manifest.js` existing mechanism like below

![Sélection_563](https://user-images.githubusercontent.com/642120/141224500-250ac74d-f9d8-47e8-b64a-0c92ed390cab.png)

Follow-up to previous question from #511 and answer

Current limitation: do not deal with CORS issues like for URLs like https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_roads.zip
Also make options `target`, `directSave`, `displayAll` and `quickView` ignored due to overload by `manifest.js` file content 
https://github.com/mbloch/mapshaper/blob/master/bin/mapshaper-gui#L204

Inherited from existing mechanism as https://mapshaper.org/?files=https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_roads.zip does not work whereas 
https://mapshaper.org/?files=https://labs.webgeodatavore.com/partage/ne_10m_roads.zip works (same data, just with less limitations on CORS side)