### PR TITLE
fix import path of geojson-common

### DIFF
--- a/src/geojson/geojson-export.mjs
+++ b/src/geojson/geojson-export.mjs
@@ -9,7 +9,7 @@ import { mergeLayerNames } from '../commands/mapshaper-merge-layers';
 import { setCoordinatePrecision } from '../geom/mapshaper-rounding';
 import { copyDatasetForExport } from '../dataset/mapshaper-dataset-utils';
 import { encodeString } from '../text/mapshaper-encodings';
-import GeoJSON from '../geojson/geojson-common';
+import GeoJSON from './geojson-common';
 import { message, error, stop } from '../utils/mapshaper-logging';
 import utils from '../utils/mapshaper-utils';
 import { Bounds } from '../geom/mapshaper-bounds';

--- a/src/geojson/geojson-import.mjs
+++ b/src/geojson/geojson-import.mjs
@@ -1,5 +1,5 @@
 import { verbose } from '../utils/mapshaper-logging';
-import GeoJSON from '../geojson/geojson-common';
+import GeoJSON from './geojson-common';
 import utils from '../utils/mapshaper-utils';
 import { PathImporter } from '../paths/mapshaper-path-import';
 import { copyRecord } from '../datatable/mapshaper-data-utils';


### PR DESCRIPTION
`geojson-export.mjs` and `geojson-import.mjs` are found in the same directory as `geojson-common` thus I thought it's cleaner to have the relative path direct instead of going back then forward into the same directory it may causes confusion.