### PR TITLE
hoist option

### DIFF
--- a/src/cli/mapshaper-options.mjs
+++ b/src/cli/mapshaper-options.mjs
@@ -315,6 +315,9 @@ export function getOptionParser() {
       describe: '[GeoJSON/JSON] output newline-delimited features or records',
       type: 'flag'
     })
+    .option('hoist', {
+      describe: '[GeoJSON] move properties to the root level',
+    })
     .option('width', {
       describe: '[SVG/TopoJSON] pixel width of output (SVG default is 800)',
       type: 'number'

--- a/src/cli/mapshaper-options.mjs
+++ b/src/cli/mapshaper-options.mjs
@@ -316,7 +316,8 @@ export function getOptionParser() {
       type: 'flag'
     })
     .option('hoist', {
-      describe: '[GeoJSON] move properties to the root level',
+      describe: '[GeoJSON] move properties to the root level of each Feature',
+      type: 'strings'
     })
     .option('width', {
       describe: '[SVG/TopoJSON] pixel width of output (SVG default is 800)',

--- a/test/geojson-test.mjs
+++ b/test/geojson-test.mjs
@@ -8,8 +8,40 @@ var fixPath = helpers.fixPath;
 
 describe('mapshaper-geojson.js', function () {
 
+  describe('-o hoist option', function() {
+
+    it('hoist= moves output properties to root of feature', async function() {
+      var data = [{
+        id: 'a', tippecanoe: { "maxzoom" : 9, "minzoom" : 4 }, foo: 'bar'
+      }];
+      var cmd = '-i data.json -o a.geojson hoist=id,tippecanoe -o b.geojson';
+      var out = await api.applyCommands(cmd, {'data.json': data});
+      var a = JSON.parse(out['a.geojson']);
+      var b = JSON.parse(out['b.geojson']);
+      assert.deepEqual(a, {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          tippecanoe: {maxzoom: 9, minzoom: 4},
+          id: 'a',
+          properties: {foo: 'bar'},
+          geometry: null
+        }]
+      })
+      // hoisting doesn't affect subsequent exports
+      assert.deepEqual(b, {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          properties: {foo: 'bar', tippecanoe: {maxzoom: 9, minzoom: 4}, id: 'a'},
+          geometry: null
+        }]
+      })
+    });
+  });
+
   describe('ndjson input', function () {
-    // TODO: support reading ndjson
+    console.log('TODO: support reading ndjson')
     false && it('reads features from an ndjson string', function (done) {
       var a = {
         type: 'Feature',


### PR DESCRIPTION
This option would allow to move properties to the root level of features like so:
``` powershell
mapshaper `
-rectangle bbox=5.98,47.30,15.01,54.98 `
-each "id='Germany';tippecanoe={minzoom:1,maxzoom:2,layer:'bbox'};untouched='still in properties'" `
-o bboxDE_hoisted.json hoist="id,tippecanoe"
```

Output **bboxDE_hoisted.json**:
``` JSON
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": { "type": "Polygon", "coordinates": [[[5.98, 47.3],[15.01, 47.3],[15.01, 54.98],[5.98, 54.98],[5.98, 47.3]]]},
      "properties": { "untouched": "still in properties" },
      "id": "Germany",
      "tippecanoe": { "minzoom": 1, "maxzoom": 2, "layer": "bbox" }
    }
  ]
}
```

The [GeoJSON extension](https://github.com/felt/tippecanoe#geojson-extension) of [Tippecanoe](https://github.com/felt/tippecanoe) is the main reason I want this feature. The suggested postprocessing step with [ndjson-cli](https://github.com/mbostock/ndjson-cli/blob/master/README.md) does not always work and is a step I would like to avoid.

This option is intentionally designed  generic (and not tippecanoe specific) because I think it can be useful in other situations as well. For example having `id` on root level is [not uncommon](https://github.com/qgis/QGIS/issues/40805) and sometimes needed as it is part of the [GeoJSON Standard](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2)


