### PR TITLE
bun support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To suggest improvements, add an [issue](https://github.com/mbloch/mapshaper/issu
 Mapshaper includes several command line programs, which can be run under Mac OS X, Linux and Windows.
 
 * `mapshaper` Runs mapshaper commands.
+* `mapshaper-bun` Runs mapshaper commands with [bun](https://bun.sh/) instead of node.
 * `mapshaper-xl` Works the same as `mapshaper`, but runs with more RAM to support larger files.
 * `mapshaper-gui` Runs the mapshaper Web interface locally.
 
@@ -26,7 +27,7 @@ For a detailed reference, see the [Command Reference](https://github.com/mbloch/
 
 ## Interactive web interface
 
-Visit the public website at [www.mapshaper.org](http://www.mapshaper.org) or use the web UI locally via the `mapshaper-gui` script. 
+Visit the public website at [www.mapshaper.org](http://www.mapshaper.org) or use the web UI locally via the `mapshaper-gui` script.
 
 All processing is done in the browser, so your data stays private, even when using the public website.
 

--- a/bin/mapshaper-bun
+++ b/bin/mapshaper-bun
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+var mapshaper = require('../mapshaper.js');
+mapshaper.enableLogging();
+mapshaper.runCommands(process.argv.slice(2), done);
+function done(err) {
+  process.exit(err ? 1 : 0);
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "bin": {
     "mapshaper": "bin/mapshaper",
+    "mapshaper-bun": "bin/mapshaper-bun",
     "mapshaper-gui": "bin/mapshaper-gui",
     "mapshaper-xl": "bin/mapshaper-xl"
   },


### PR DESCRIPTION
mapshaper runs great with bun, no more out of memory errors when there still is available memory. this adds `bin/mapshaper-bun` to run mapshaper with bun instead of node. 