### PR TITLE
Fix npm run build on Linux hosts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,6 +289,19 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
+      "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@tmcw/togeojson": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@tmcw/togeojson/-/togeojson-5.6.0.tgz",


### PR DESCRIPTION
Running `npm run build` on Linux hosts requires adding `node_modules/@rollup/rollup-linux-x64-gnu` to *package-lock.json*.  Otherwise the following error message is generated:

```
> mapshaper@0.6.105 build
> rollup --config

/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js:64
                throw new Error(
                ^

Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
    at requireWithFriendlyError (/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js:64:9)
    at Object.<anonymous> (/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js:73:76)
    ... 3 lines matching cause stack trace ...
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/data/tmp/src/mapshaper/node_modules/rollup/dist/shared/parseAst.js:12:19)
    at Module._compile (node:internal/modules/cjs/loader:1469:14) {
  [cause]: Error: Cannot find module '@rollup/rollup-linux-x64-gnu'
  Require stack:
  - /data/tmp/src/mapshaper/node_modules/rollup/dist/native.js
  - /data/tmp/src/mapshaper/node_modules/rollup/dist/shared/parseAst.js
  - /data/tmp/src/mapshaper/node_modules/rollup/dist/shared/rollup.js
  - /data/tmp/src/mapshaper/node_modules/rollup/dist/bin/rollup
      at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
      at Module._load (node:internal/modules/cjs/loader:1051:27)
      at Module.require (node:internal/modules/cjs/loader:1311:19)
      at require (node:internal/modules/helpers:179:18)
      at requireWithFriendlyError (/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js:46:10)
      at Object.<anonymous> (/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js:73:76)
      at Module._compile (node:internal/modules/cjs/loader:1469:14)
      at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
      at Module.load (node:internal/modules/cjs/loader:1288:32)
      at Module._load (node:internal/modules/cjs/loader:1104:12) {
    code: 'MODULE_NOT_FOUND',
    requireStack: [
      '/data/tmp/src/mapshaper/node_modules/rollup/dist/native.js',
      '/data/tmp/src/mapshaper/node_modules/rollup/dist/shared/parseAst.js',
      '/data/tmp/src/mapshaper/node_modules/rollup/dist/shared/rollup.js',
      '/data/tmp/src/mapshaper/node_modules/rollup/dist/bin/rollup'
    ]
  }
}

Node.js v20.18.1
```
