### PR TITLE
Wrap paths with quotes during exec

### DIFF
--- a/src/cli/mapshaper-run-commands.mjs
+++ b/src/cli/mapshaper-run-commands.mjs
@@ -65,7 +65,7 @@ export function runCommandsXL(argv) {
   }
   if (!loggingEnabled()) argv += ' -quiet'; // kludge to pass logging setting to subprocess
   var mb = Math.round(gb * 1000);
-  var command = [process.execPath, '--max-old-space-size=' + mb, mapshaperScript, argv].join(' ');
+  var command = [`"${process.execPath}"`, '--max-old-space-size=' + mb, `"${mapshaperScript}"`, argv].join(' ');
   var child = require('child_process').exec(command, {}, function(err, stdout, stderr) {
     opts.callback(err);
   });


### PR DESCRIPTION
If there is a space in the Node.js executable's path (such as in Windows systems; e.g. `C:\Program Files\nodejs\...`) or in the path to the mapshaper script (i.e. the path of the folder containing the `node_modules` where mapshaper is installed), attempting to run `mapshaper.runCommandsXL` will fail as the script tries to spawn a new process and the shell interprets the space as the start of a new argument and not as part of a path.

This just wraps both the Node.js executable path and the mapshaper script path in quotes so that the shell (be it cmd or bash) will properly interpret those paths as one argument.