### PR TITLE
fix: make adm-zip construction Bun-compatible

### DIFF
--- a/src/io/mapshaper-zip.mjs
+++ b/src/io/mapshaper-zip.mjs
@@ -86,7 +86,8 @@ export function isImportableZipPath(name) {
 
 // input: input file path or a Buffer containing .zip file bytes
 function unzipSyncNode(input) {
-  var zip = new require('adm-zip')(input);
+  var AdmZip = require('adm-zip');
+  var zip = new AdmZip(input);
   var index = {};
   zip.getEntries().forEach(function(entry) {
     // entry.entryName // path, including filename
@@ -100,7 +101,8 @@ function unzipSyncNode(input) {
 }
 
 function zipSyncNode(files) {
-  var zip = new require('adm-zip')();
+  var AdmZip = require('adm-zip');
+  var zip = new AdmZip();
   files.forEach(function(o) {
     var buf = o.content;
     if (buf instanceof ArrayBuffer) {


### PR DESCRIPTION
## Summary

Importing a `.zip` (e.g. a zipped shapefile) fails under [Bun](https://bun.sh) with:

```
TypeError: function is not a constructor (evaluating 'new require("adm-zip")')
```

## Root cause

`unzipSyncNode`/`zipSyncNode` in `src/io/mapshaper-zip.mjs` construct the zip reader with:

```js
var zip = new require('adm-zip')(input);
```

Because of how `new Expr(args1)(args2)` parses, this is actually `(new require('adm-zip'))(input)` — `new` is applied to `require` itself, using `'adm-zip'` as its argument, and the *result* of that (the module, since `require` explicitly returns an object) is then called with `input`, without `new`.

This only works at all because:
- Node's `require` is a constructible function, and explicitly returns an object (the module export), so `new require('adm-zip')` evaluates to the `AdmZip` constructor itself — the `new` never actually reaches `AdmZip`.
- `AdmZip` happens to still behave correctly when invoked without `new` in Node's module wrapper (`this` falls back to the global object).

Bun's `require` is **not constructible** (`require.prototype === undefined`), so `new require('adm-zip')` throws immediately, before `AdmZip` is ever reached. This breaks every code path that imports a `.zip` file under Bun.

## Fix

Split the `require` call from the `new` construction, matching the pattern already used a few lines above in `listZipEntryNames`:

```js
var AdmZip = require('adm-zip');
var zip = new AdmZip(input);
```

## Testing

- `npm test` — same result before/after this change: 3763 passing, 35 pre-existing failures in `geopackage-import-test.mjs` unrelated to this change (native-binding timeouts, reproduced identically on unmodified `master`).
- `npx mocha --require test/mocha-hooks.mjs test/zip-test.mjs` — 9/9 passing.
- Manual repro: `bin/mapshaper -i shapefile.zip -o out.topojson`
  - Before: throws `TypeError: function is not a constructor` under `bun bin/mapshaper ...`
  - After: succeeds under both `node bin/mapshaper ...` and `bun bin/mapshaper ...`